### PR TITLE
Add Support for Transport Layer Security TLS1.2

### DIFF
--- a/SlackNotifier.cs
+++ b/SlackNotifier.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Net.ServicePointManager;
 using System.Text;
 using System.Threading.Tasks;
 using SVNSlackNotifier.Helpers;
@@ -28,6 +29,9 @@ namespace SVNSlackNotifier
                     Logger.Shared.WriteError("Missing revision number");
                 else
                 {
+                    // Supporting protocol TLS 1.0 / 1.1 / 1.2
+                    SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+
                     // Post to Slack
                     using (var client = new HttpClient())
                     {


### PR DESCRIPTION
Slack will discontinue support for Transport Layer Security(TLS) 1.0 / 1.1.
Therefore, this application need to supprt TLS 1.2.

See: https://slack.com/help/articles/360024438834-Transport-Layer-Security--TLS--in-Slack

issue #12 